### PR TITLE
add init.lua sourcing edconf.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,4 @@
+local source_str = debug.getinfo(1, 'S').source:sub(2)
+local script_path = source_str:match('(.*/)')
+
+return dofile(script_path .. 'edconf.lua')


### PR DESCRIPTION
This allows vis-editorconfig to be loaded in visrc.lua by simply
using `require('path/to/vis-editorconfig')`