### PR TITLE
Fix incorrect path variable check

### DIFF
--- a/edconf.lua
+++ b/edconf.lua
@@ -178,7 +178,7 @@ function ec_iter(p)
 end
 
 function ec_set_values(file)
-  if path then
+  if file.path then
     for name, value in ec_iter(file.path) do
       if OPTIONS[name] then
         OPTIONS[name](value, file)


### PR DESCRIPTION
Fixes the incorrect variable name used to check whether the path is valid.

Signed-off-by: Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>