### PR TITLE
fix insert_final_newline for empty files

### DIFF
--- a/edconf.lua
+++ b/edconf.lua
@@ -36,7 +36,7 @@ function insert_final_newline(file, path)
   -- therefore respect edconf_hooks_enabled. Since this function runs
   -- blazingly fast and scales with a complexity of O(1), however,
   -- there is no need to disable it.
-  if file:content(file.size-1, 1) ~= '\n' then
+  if file.size > 0 and file:content(file.size-1, 1) ~= '\n' then
     file:insert(file.size, '\n')
   end
 end


### PR DESCRIPTION
When saving an empty file in a directory containing an editorconfig
using the insert_final_newline option the content lookup 'file.size-1'
fails.

Fix this by only adding a final newline if the file contains any data.

Signed-off-by: Florian Fischer <florian.fischer@muhq.space>